### PR TITLE
Add description field to pchests to make them renamable

### DIFF
--- a/pchest.lua
+++ b/pchest.lua
@@ -133,7 +133,11 @@ minetest.register_node("hook:pchest_node", {
 		return m:get_string("owner") == "" and m:get_inventory():is_empty("main")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
+		local name = sender:get_player_name()
 		local meta = minetest.get_meta(pos)
+		if name ~= meta:get_string("owner") then
+			return false
+		end
 		if fields.description_textbox then
 			meta:set_string("description", fields.description_textbox)
 		end


### PR DESCRIPTION
Duplicating [this PR](https://github.com/AiTechEye/hook/pull/5) as the project looks unmaintained

Fixes issue 4 https://github.com/AiTechEye/hook/issues/4

Made portable chests renamable by adding a "description" field to the formspec, which is saved as "description" in the item's metadata. This overrides the default description to effectively rename the item once you have picked it up.

This also involved separating out the formspec function from the setup so we can call it again to update the form once it is submitted.

Description defaults to "Portable locked chest"

This new description could also be used to update the infotext, I decided against that since you can just look inside the chest if it's placed down, if you'd like me to make that change in this PR too, let me know.